### PR TITLE
Include database resource requirement for authClient

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,16 @@ export default App;
 
 ### Auth Client
 The package lets you manage the login/logout process implementing an optional `authClient` prop of the `Admin` component [(see documentation)](https://marmelab.com/admin-on-rest/Authentication.html).  
-It stores a `firebaseToken` in  `localStorage`.  
+It stores a `firebaseToken` in  `localStorage`.
+
+This requires a `users` resource relative to the root, with the user IDs as the children and an `isAdmin` boolean value.
+
+```
+app-name
++- users
+   +- USERID-FROM-FIREBASE-AUTH
+      +- isAdmin: true
+```
 
 
 ```js


### PR DESCRIPTION
While attempting to use authClient authentication, I was slightly confused as to what the error messages meant. Only after looking through the source of authClient.js did I realise that I needed a `users` resource at the database root.

This PR includes this information in the Readme.