### PR TITLE
Add support for sorting

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,6 +9,10 @@
     "prepare": "yarn run build"
   },
   "author": "Sid Ferreira",
+  "repository" : {
+    "type" : "git",
+    "url" : "https://github.com/sidferreira/aor-firebase-client.git"
+  },
   "license": "ISC",
   "files": [
     "LICENSE",
@@ -23,6 +27,7 @@
     "rest"
   ],
   "dependencies": {
+    "array-sort": "^0.1.4",
     "firebase": "^4.1.3",
     "react": "^15.6.1"
   },

--- a/src/restClient.js
+++ b/src/restClient.js
@@ -1,4 +1,5 @@
 import firebase from 'firebase'
+import arraySort from 'array-sort'
 
 import {
   GET_LIST,
@@ -137,6 +138,10 @@ export default (trackedResources = [], firebaseConfig = {}, options = {}) => {
                 })
               } else {
                 values = Object.values(resourcesData[resource])
+              }
+
+              if(params.sort) {
+                arraySort(values, params.sort.field, {reverse: params.sort.order !== 'ASC'})
               }
 
               const {page, perPage} = params.pagination


### PR DESCRIPTION
As [requested](https://github.com/sidferreira/aor-firebase-client/pull/22#issuecomment-331325296), this PR separates the sorting functionality from the auth status.

Adds a dependency for https://github.com/jonschlinkert/array-sort

Also fixes warning about missing "repository" field during `npm install`