### PR TITLE
Fix - Get many was dumping result of query by selected IDs

### DIFF
--- a/src/methods.js
+++ b/src/methods.js
@@ -116,6 +116,8 @@ const getMany = (params, resourceName, resourceData) => {
       }
       return total
     })
+
+
   } else if (params.pagination) {
     /** GET_LIST / GET_MANY_REFERENCE */
     let values = []
@@ -161,10 +163,11 @@ const getMany = (params, resourceName, resourceData) => {
     data = values.slice(_start, _end)
     ids = keys.slice(_start, _end)
     total = values.length
-    return { data, ids, total }
   } else {
     throw new Error('Error processing request')
   }
+
+  return { data, ids, total }
 }
 
 export default {


### PR DESCRIPTION
Found and fixed bug happening when using Referrence fields in lists. Result of get_many with selected IDs was dumped in RestClient and so data for relation were never fetched. 